### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,12 @@ env:
 before_install:
   - test "${TRAVIS_BRANCH}" != 'coverity_scan' -o "${TRAVIS_JOB_NUMBER##*.}" = '1' || exit 0
   - echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-
+  - |
+     sudo systemctl stop apt-daily.service &&
+     sudo systemctl kill --kill-who=all apt-daily.service &&
+     while ! (systemctl list-units --all apt-daily.service | fgrep -q dead) ; do
+       sleep 1
+     done
   - pip install --user cpp-coveralls
   - sudo apt-get -qq update
   - sudo apt-get install -y build-essential


### PR DESCRIPTION
Like what we did in commit 14a2088 for libva, the corresponding fix is
also required for libva-utils to avoid locking dpkg file by an
unattended `apt-get` call
