### PR TITLE
Use the new link URLs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,14 +36,14 @@ before_install:
   - sudo apt-get install -y libxfixes-dev
 
 install:
-  - git clone https://github.com/01org/libva.git
+  - git clone https://github.com/intel/libva.git
   - (cd libva && ./autogen.sh && ./configure --prefix=/usr && sudo make install)
 
 
 addons:
   coverity_scan:
     project:
-      name: "01org/libva-utils"
+      name: "intel/libva-utils"
       description: "Build submitted via Travis CI"
     notification_email: intel-media-security@lists.01.org 
     build_command_prepend: "./autogen.sh; ./configure --prefix=/usr"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,11 @@ We accept github pull requests.
 
 Once you've finished making your changes push them to your fork and send the PR via the github UI.
 
-## Issue tracking
+## Reporting a security issue
+
+Please mail to secure-opensource@intel.com directly for security issue
+
+## Public issue tracking
 
 If you have a problem, please let us know.  IRC is a perfectly fine place
 to quickly informally bring something up, if you get a response.  The
@@ -53,14 +57,14 @@ to quickly informally bring something up, if you get a response.  The
 is a more durable communication channel.
 
 If it's a bug not already documented, by all means please [open an
-issue in github](https://github.com/01org/libva-utils/issues/new) so we all get visibility
+issue in github](https://github.com/intel/libva-utils/issues/new) so we all get visibility
 to the problem and can work towards a resolution.
 
 For feature requests we're also using github issues, with the label
 "enhancement".
 
 Our github bug/enhancement backlog and work queue are tracked in a
-[Libva-utils waffle.io kanban](https://waffle.io/01org/libva-utils).
+[Libva-utils waffle.io kanban](https://waffle.io/intel/libva-utils).
 
 ## Closing issues
 

--- a/INSTALL
+++ b/INSTALL
@@ -1,4 +1,4 @@
-[![Stories in Ready](https://badge.waffle.io/01org/libva-utils.png?label=ready&title=Ready)](https://waffle.io/01org/libva-utils)
+[![Stories in Ready](https://badge.waffle.io/intel/libva-utils.png?label=ready&title=Ready)](https://waffle.io/intel/libva-utils)
   libva-utils
   Collection of tests to exercise VA-API as provided
   by the libva project.  VA-API requires a driver implementation
@@ -22,7 +22,7 @@ operate.
 
 
 Project is hosted on github:
-https://github.com/01org/libva-utils
+https://github.com/intel/libva-utils
 
 Codecs
 ------
@@ -101,4 +101,4 @@ Reporting Bugs / Submit change patches
 
 See the contributing guide:
 
-https://github.com/01org/libva-utils/blob/master/CONTRIBUTING.md
+https://github.com/intel/libva-utils/blob/master/CONTRIBUTING.md

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![Stories in Ready](https://badge.waffle.io/01org/libva-utils.png?label=ready&title=Ready)](http://waffle.io/01org/libva-utils)
-[![Build Status](https://travis-ci.org/01org/libva-utils.svg?branch=master)](https://travis-ci.org/01org/libva-utils)
-[![Coverity Scan Build Status](https://scan.coverity.com/projects/11613/badge.svg)](https://scan.coverity.com/projects/01org-libva-utils)
+[![Stories in Ready](https://badge.waffle.io/intel/libva-utils.png?label=ready&title=Ready)](http://waffle.io/intel/libva-utils)
+[![Build Status](https://travis-ci.org/intel/libva-utils.svg?branch=master)](https://travis-ci.org/intel/libva-utils)
+[![Coverity Scan Build Status](https://scan.coverity.com/projects/11613/badge.svg)](https://scan.coverity.com/projects/intel-libva-utils)
 
 #Libva-utils Project
 
@@ -16,10 +16,10 @@ driver-specific acceleration backends for each supported hardware
 vendor.
 
 If you would like to contribute to libva, check our [Contributing
-guide](https://github.com/01org/libva-utils/blob/master/CONTRIBUTING.md).
+guide](https://github.com/intel/libva-utils/blob/master/CONTRIBUTING.md).
 
 We also recommend taking a look at the ['janitorial'
-bugs](https://github.com/01org/libva-utils/issues?q=is%3Aopen+is%3Aissue+label%3AJanitorial)
+bugs](https://github.com/intel/libva-utils/issues?q=is%3Aopen+is%3Aissue+label%3AJanitorial)
 in our list of open issues as these bugs can be solved without an
 extensive knowledge of libva-utils.
 

--- a/configure.ac
+++ b/configure.ac
@@ -52,9 +52,9 @@ m4_define([wayland_api_version], [1.0.0])
 AC_PREREQ(2.57)
 AC_INIT([libva_utils],
         [libva_utils_version],
-        [https://github.com/01org/libva-utils/issues/new],
+        [https://github.com/intel/libva-utils/issues/new],
         [libva-utils],
-        [https://github.com/01org/libva-utils])
+        [https://github.com/intel/libva-utils])
 AC_CONFIG_SRCDIR([Makefile.am])
 AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([dist-bzip2])


### PR DESCRIPTION
We moved libva from github/01org to github/intel, however some files
still have links to the old 01org URLs, this commit updates these
links to the new intel URLs. In addition, this commit added a contact
email address for security issue reporting

https://github.com/intel/libva-utils/issues/103
