### PR TITLE
test: remove i965 driver specific cases

### DIFF
--- a/test/test_va_api_init_terminate.cpp
+++ b/test/test_va_api_init_terminate.cpp
@@ -55,29 +55,6 @@ TEST_F(VAAPIInitTerminate, vaInitialize_vaTerminate)
     doInitTerminate();
 }
 
-TEST_F(VAAPIInitTerminate, vaInitialize_vaTerminate_i965_Environment)
-{
-    EXPECT_EQ(0, setenv("LIBVA_DRIVER_NAME", "i965", 1))
-        << "Could not set enviroment variable";
-    doInitTerminate();
-    EXPECT_EQ(0, unsetenv("LIBVA_DRIVER_NAME"))
-        << "Could not un-set enviroment variable";
-}
-
-TEST_F(VAAPIInitTerminate, vaInitialize_vaTerminate_i965_vaSetDriverName)
-{
-    int major, minor;
-    char driver[5] = "i965";
-
-    VADisplay display = getDisplay();
-    ASSERT_TRUE(display);
-
-    ASSERT_STATUS(vaSetDriverName(display, driver));
-
-    ASSERT_STATUS(vaInitialize(display, &major, &minor));
-    EXPECT_STATUS(vaTerminate(display));
-}
-
 TEST_F(VAAPIInitTerminate, vaInitialize_vaTerminate_Bad_Environment)
 {
     int major, minor;

--- a/test/test_va_api_query_vendor.cpp
+++ b/test/test_va_api_query_vendor.cpp
@@ -32,7 +32,7 @@ namespace VAAPI {
 
 typedef VAAPIFixture VAAPIQueryVendor;
 
-TEST_F(VAAPIQueryVendor, Intel_i965_Vendor)
+TEST_F(VAAPIQueryVendor, NotEmpty)
 {
     int major, minor;
 
@@ -41,9 +41,7 @@ TEST_F(VAAPIQueryVendor, Intel_i965_Vendor)
 
     ASSERT_STATUS(vaInitialize(display, &major, &minor));
     const std::string vendor(vaQueryVendorString(display));
-    EXPECT_NE(std::string::npos, vendor.find("Intel i965 driver"))
-        << "Couldn't find Vendor Name in " << vendor << std::endl;
-
+    EXPECT_GT(vendor.size(), 0u);
     ASSERT_STATUS(vaTerminate(display));
 }
 


### PR DESCRIPTION
Conformance tests should be as generic as possible and
not assume availability of any specific driver.

Fixes #93
Fixes #94
Fixes #95

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>