### PR TITLE
Check for -fstack-protector

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -129,6 +129,22 @@ if test "$ac_cv_have_gnuc_visibility_attribute" = "yes"; then
               [Defined to 1 if GCC visibility attribute is supported])
 fi
 
+# Check for -fstack-protector
+ssp_cc=yes
+if test "X$CC-cc" != "X"; then
+    AC_MSG_CHECKING([whether ${CC-cc} accepts -fstack-protector])
+    ssp_old_cflags="$CFLAGS"
+    CFLAGS="$CFLAGS -fstack-protector"
+    AC_LINK_IFELSE([AC_LANG_PROGRAM([[]], [[alloca(100);]])], [], [ssp_cc=no])
+    AC_MSG_RESULT([$ssp_cc])
+    if test "X$ssp_cc" = "Xno"; then
+        CFLAGS="$ssp_old_cflags"
+    else
+        AC_DEFINE([ENABLE_SSP_CC], 1, [Define if SSP C support is enabled.])
+    fi
+fi
+AM_CONDITIONAL(USE_SSP, test "$ssp_cc" = "yes")
+
 # Check for DRM (mandatory)
 LIBDRM_VERSION=libdrm_version
 PKG_CHECK_MODULES([DRM], [libdrm >= $LIBDRM_VERSION])

--- a/decode/Makefile.am
+++ b/decode/Makefile.am
@@ -24,10 +24,13 @@ bin_PROGRAMS = mpeg2vldemo loadjpeg
 
 AM_CPPFLAGS = \
 	-Wall					\
-	-fstack-protector			\
 	$(LIBVA_CFLAGS)				\
 	-I$(top_srcdir)/common			\
 	$(NULL)
+
+if USE_SSP
+AM_CPPFLAGS += -fstack-protector
+endif
 
 TEST_LIBS = \
 	$(LIBVA_LIBS)				\

--- a/encode/Makefile.am
+++ b/encode/Makefile.am
@@ -25,9 +25,12 @@ noinst_PROGRAMS = svctenc
 
 AM_CPPFLAGS = \
 	-Wall				\
-	-fstack-protector		\
 	$(LIBVA_CFLAGS) 		\
 	$(NULL)
+
+if USE_SSP
+AM_CPPFLAGS += -fstack-protector
+endif
 
 h264encode_SOURCES	= h264encode.c
 h264encode_CFLAGS	= -I$(top_srcdir)/common -g

--- a/putsurface/Makefile.am
+++ b/putsurface/Makefile.am
@@ -26,8 +26,11 @@ TEST_CFLAGS = \
 	$(LIBVA_CFLAGS)			\
 	-I$(top_srcdir)/common		\
 	-Wall				\
-	-fstack-protector		\
 	$(NULL)
+
+if USE_SSP
+TEST_CFLAGS += -fstack-protector
+endif
 
 TEST_LIBS = \
 	$(LIBVA_LIBS)		\

--- a/vainfo/Makefile.am
+++ b/vainfo/Makefile.am
@@ -27,8 +27,11 @@ vainfo_cflags = \
 	$(LIBVA_CFLAGS) \
 	-DLIBVA_VERSION_S="\"$(LIBVA_VERSION)\"" \
 	-Wall \
-	-fstack-protector \
 	$(NULL)
+
+if USE_SSP
+vainfo_cflags += -fstack-protector
+endif
 
 vainfo_libs = \
        	$(LIBVA_LIBS) \

--- a/videoprocess/Makefile.am
+++ b/videoprocess/Makefile.am
@@ -24,10 +24,13 @@ bin_PROGRAMS = vavpp
 
 AM_CPPFLAGS = \
 	-Wall					\
-	-fstack-protector			\
 	$(LIBVA_CFLAGS)				\
 	-I$(top_srcdir)/common			\
 	$(NULL)
+
+if USE_SSP
+AM_CPPFLAGS += -fstack-protector
+endif
 
 TEST_LIBS = \
 	$(LIBVA_LIBS)				\


### PR DESCRIPTION
Not all toolchains provide support for -fstack-protector. This patch
provides a configure check to avoid build errors like

/home/buildroot/buildroot/output/host/opt/ext-toolchain/bin/../lib/gcc/x86_64-buildroot-linux-uclibc/6.4.0/../../../../x86_64-buildroot-linux-uclibc/bin/ld: cannot find -lssp_nonshared
/home/buildroot/buildroot/output/host/opt/ext-toolchain/bin/../lib/gcc/x86_64-buildroot-linux-uclibc/6.4.0/../../../../x86_64-buildroot-linux-uclibc/bin/ld: cannot find -lssp