### PR TITLE
meson: rename the h264enc binary to be in line with the autotools build

### DIFF
--- a/encode/meson.build
+++ b/encode/meson.build
@@ -5,7 +5,7 @@ m = c.find_library('m')
 executable('avcenc', [ 'avcenc.c' ],
            dependencies: [ libva_display_dep, threads ],
            install: true)
-executable('h264enc', [ 'h264encode.c' ],
+executable('h264encode', [ 'h264encode.c' ],
            dependencies: [ libva_display_dep, threads, m ],
            install: true)
 executable('mpeg2vaenc', [ 'mpeg2vaenc.c' ],


### PR DESCRIPTION
h264enc collides with the h264enc binary installed by openh264 and the
autotools based build names the binary h264encode.