### PR TITLE
Include .h for extra dist

### DIFF
--- a/vendor/intel/Makefile.am
+++ b/vendor/intel/Makefile.am
@@ -42,3 +42,7 @@ valgrind:	$(bin_PROGRAMS)
 	for a in $(bin_PROGRAMS); do \
 		valgrind --leak-check=full --show-reachable=yes .libs/$$a; \
 	done
+
+EXTRA_DIST = 			\
+	avcstreamoutdemo.h 	\
+	$(NULL)

--- a/vendor/intel/sfcsample/Makefile.am
+++ b/vendor/intel/sfcsample/Makefile.am
@@ -52,4 +52,7 @@ valgrind:$(bin_PROGRAMS)
 		valgrind --leak-check=full --show-reachable=yes .libs/$$a; \
 	done
 
-
+EXTRA_DIST =		\
+	VDecAccelVA.h 	\
+	DecodeParamBuffer.h	\
+	$(NULL)


### PR DESCRIPTION
Otherwise the package made by 'make dist' fails to build with similar
errors below:

  CC       avcstreamoutdemo.o
avcstreamoutdemo.c:46:10: fatal error: avcstreamoutdemo.h: No such file
or directory
 #include "avcstreamoutdemo.h"
          ^~~~~~~~~~~~~~~~~~~~
compilation terminated.
Makefile:456: recipe for target 'avcstreamoutdemo.o' failed
make[1]: *** [avcstreamoutdemo.o] Error 1
