### PR TITLE
only build sfcsample when x11 is enabled

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -24,10 +24,10 @@ ACLOCAL_AMFLAGS = -I m4 ${ACLOCAL_FLAGS}
 
 AUTOMAKE_OPTIONS = foreign
 
-SUBDIRS = common decode encode vainfo videoprocess vendor/intel vendor/intel/sfcsample
+SUBDIRS = common decode encode vainfo videoprocess vendor/intel
 
 if USE_X11
-SUBDIRS += putsurface
+SUBDIRS += putsurface vendor/intel/sfcsample
 else
 if USE_WAYLAND
 SUBDIRS += putsurface


### PR DESCRIPTION
This fixes a non x11 enabled build

This fixes #150 