### PR TITLE
sfcsample: don't include va_x11.h

### DIFF
--- a/vendor/intel/sfcsample/VDecAccelVA.cpp
+++ b/vendor/intel/sfcsample/VDecAccelVA.cpp
@@ -42,7 +42,6 @@
 #include "VDecAccelVA.h"
 #include <va/va.h>
 #include <va/va_drm.h>
-#include <va/va_x11.h>
 
 #define VASUCCEEDED(err)    (err == VA_STATUS_SUCCESS)
 #define VAFAILED(err)       (err != VA_STATUS_SUCCESS)


### PR DESCRIPTION
There is no dependency on va/x11