### PR TITLE
X11 is never used, so don't include the headers

### DIFF
--- a/vendor/intel/sfcsample/VDecAccelVA.cpp
+++ b/vendor/intel/sfcsample/VDecAccelVA.cpp
@@ -42,7 +42,6 @@
 #include "VDecAccelVA.h"
 #include <va/va.h>
 #include <va/va_drm.h>
-#include <va/va_x11.h>
 
 #define VASUCCEEDED(err)    (err == VA_STATUS_SUCCESS)
 #define VAFAILED(err)       (err != VA_STATUS_SUCCESS)

--- a/vendor/intel/sfcsample/VDecAccelVA.h
+++ b/vendor/intel/sfcsample/VDecAccelVA.h
@@ -39,9 +39,6 @@
 #include <va/va.h>
 #include "DecodeParamBuffer.h"
 
-#include <X11/Xlib.h>
-typedef Display*     HDISP;
-
 namespace mvaccel
 {
 /**


### PR DESCRIPTION
1. Fix sfcsample dx11 can't compile issue. id#150
~~2. Dump both decode and downscaled surface~~