### PR TITLE
Align libva attribute check 

### DIFF
--- a/test/test_data.h
+++ b/test/test_data.h
@@ -201,7 +201,8 @@ static const BufferTypes g_vaBufferTypes = {
 
 static const BitMasks g_vaRateControls = {
     VA_RC_NONE, VA_RC_CBR, VA_RC_VBR, VA_RC_VCM, VA_RC_CQP,
-    VA_RC_VBR_CONSTRAINED, VA_RC_ICQ, VA_RC_MB, VA_RC_CFS, VA_RC_PARALLEL,
+    VA_RC_VBR_CONSTRAINED, VA_RC_ICQ, VA_RC_MB, VA_RC_CFS,
+    VA_RC_PARALLEL,VA_RC_QVBR,VA_RC_AVBR,
 };
 
 static const BitMasks g_vaDecSliceModes = {


### PR DESCRIPTION
Fix VaCreatconfig attribute check fail issue caused by missing two ratecontrol bitmasks.

 Signed-off-by: Shawn Li <shawn.li@intel.com>