### PR TITLE
Drop unused dependencies

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -173,7 +173,7 @@ AM_CONDITIONAL(USE_DRM, test "$USE_DRM" = "yes")
 # Check for X11
 USE_X11="no"
 if test "x$enable_x11" != "xno"; then
-    PKG_CHECK_MODULES([X11],    [x11 xext xfixes libva-x11],
+    PKG_CHECK_MODULES([X11],    [x11 libva-x11],
         [USE_X11="yes"], [:])
 
     if test "x$USE_X11" = "xno" -a "x$enable_x11" = "xyes"; then

--- a/configure.ac
+++ b/configure.ac
@@ -43,9 +43,6 @@ m4_append([libva_utils_version], libva_utils_pre_version, [.pre])
 # libva-utils was created
 m4_define([libva_api_min_version], [1.1.0])
 
-# libdrm minimun version requirement
-m4_define([libdrm_version], [2.4])
-
 # Wayland minimum version number
 m4_define([wayland_api_version], [1.0.0])
 
@@ -146,10 +143,7 @@ fi
 AM_CONDITIONAL(USE_SSP, test "$ssp_cc" = "yes")
 
 # Check for DRM (mandatory)
-LIBDRM_VERSION=libdrm_version
-PKG_CHECK_MODULES([DRM], [libdrm >= $LIBDRM_VERSION])
 PKG_CHECK_MODULES([LIBVA_DRM], [libva-drm])
-AC_SUBST(LIBDRM_VERSION)
 
 # Check for libva (for dynamic linking)
 LIBVA_API_MIN_VERSION=libva_api_min_version

--- a/decode/Android.mk
+++ b/decode/Android.mk
@@ -18,7 +18,7 @@ LOCAL_C_INCLUDES += \
 LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE :=	mpeg2vldemo
 
-LOCAL_SHARED_LIBRARIES := libva libva-android libdl libdrm libcutils libutils libgui
+LOCAL_SHARED_LIBRARIES := libva libva-android libdl libcutils libutils libgui
 
 include $(BUILD_EXECUTABLE)
 
@@ -41,6 +41,6 @@ LOCAL_C_INCLUDES += \
 LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE :=	loadjpeg
 
-LOCAL_SHARED_LIBRARIES := libva libva-android libdl libdrm libcutils libutils libgui
+LOCAL_SHARED_LIBRARIES := libva libva-android libdl libcutils libutils libgui
 
 include $(BUILD_EXECUTABLE)

--- a/encode/Android.mk
+++ b/encode/Android.mk
@@ -18,7 +18,7 @@ LOCAL_C_INCLUDES += \
 LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE :=	h264encode
 
-LOCAL_SHARED_LIBRARIES := libva-android libva libdl libdrm  libcutils libutils libgui libm
+LOCAL_SHARED_LIBRARIES := libva-android libva libdl  libcutils libutils libgui libm
 
 include $(BUILD_EXECUTABLE)
 
@@ -40,7 +40,7 @@ LOCAL_C_INCLUDES += \
 LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE :=	avcenc
 
-LOCAL_SHARED_LIBRARIES := libva-android libva libdl libdrm libcutils libutils libgui
+LOCAL_SHARED_LIBRARIES := libva-android libva libdl libcutils libutils libgui
 
 include $(BUILD_EXECUTABLE)
 
@@ -62,7 +62,7 @@ LOCAL_C_INCLUDES += \
 LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE :=	vp9enc
 
-LOCAL_SHARED_LIBRARIES := libva-android libva libdl libdrm libcutils libutils libgui
+LOCAL_SHARED_LIBRARIES := libva-android libva libdl libcutils libutils libgui
 
 include $(BUILD_EXECUTABLE)
 
@@ -84,7 +84,7 @@ LOCAL_C_INCLUDES += \
 LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE :=	jpegenc
 
-LOCAL_SHARED_LIBRARIES := libva-android libva libdl libdrm libcutils libutils libgui
+LOCAL_SHARED_LIBRARIES := libva-android libva libdl libcutils libutils libgui
 
 include $(BUILD_EXECUTABLE)
 
@@ -106,7 +106,7 @@ LOCAL_C_INCLUDES += \
 LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE :=	mpeg2vaenc
 
-LOCAL_SHARED_LIBRARIES := libva-android libva libdl libdrm libcutils libutils libgui
+LOCAL_SHARED_LIBRARIES := libva-android libva libdl libcutils libutils libgui
 
 include $(BUILD_EXECUTABLE)
 
@@ -128,6 +128,6 @@ LOCAL_C_INCLUDES += \
 LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE :=	svctenc
 
-LOCAL_SHARED_LIBRARIES := libva-android libva libdl libdrm libcutils libutils libgui
+LOCAL_SHARED_LIBRARIES := libva-android libva libdl libcutils libutils libgui
 
 include $(BUILD_EXECUTABLE)

--- a/meson.build
+++ b/meson.build
@@ -40,8 +40,6 @@ if get_option('x11') != 'false'
   require_x11 = get_option('x11') == 'true'
   x11_deps = [
     dependency('x11', required: require_x11),
-    dependency('xext', required: require_x11),
-    dependency('xfixes', required: require_x11),
     dependency('libva-x11', required: require_x11),
   ]
   use_x11 = true

--- a/meson.build
+++ b/meson.build
@@ -20,7 +20,6 @@ use_drm = false
 if get_option('drm') != 'false'
   require_drm = get_option('drm') == 'true'
   drm_deps = [
-    dependency('libdrm', version: '>= 2.4', required: require_drm),
     dependency('libva-drm', required: require_drm),
   ]
   use_drm = true

--- a/vainfo/Android.mk
+++ b/vainfo/Android.mk
@@ -19,7 +19,7 @@ LOCAL_C_INCLUDES += \
 LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE := vainfo
 
-LOCAL_SHARED_LIBRARIES := libva-android libva libdl libdrm libcutils libutils libgui
+LOCAL_SHARED_LIBRARIES := libva-android libva libdl libcutils libutils libgui
 
 include $(BUILD_EXECUTABLE)
 

--- a/vendor/intel/sfcsample/VDecAccelVA.cpp
+++ b/vendor/intel/sfcsample/VDecAccelVA.cpp
@@ -32,7 +32,6 @@
 #include <fcntl.h>
 #include <sys/mman.h>
 #include <sys/ioctl.h>
-#include <linux/fb.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <iostream>

--- a/videoprocess/Android.mk
+++ b/videoprocess/Android.mk
@@ -18,6 +18,6 @@ LOCAL_C_INCLUDES += \
 LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE :=	vavpp
 
-LOCAL_SHARED_LIBRARIES := libva-android libva libdl libdrm  libcutils libutils libgui libm
+LOCAL_SHARED_LIBRARIES := libva-android libva libdl libcutils libutils libgui libm
 
 include $(BUILD_EXECUTABLE)


### PR DESCRIPTION
Meson adds `-Wl,--as-needed` by default, see https://github.com/mesonbuild/meson/commit/58ca96994f5a
From [build log](https://github.com/intel/libva-utils/files/4004198/libva-utils-2.6.0.log):
```
=>> Checking shared library dependencies
 0x00000001 NEEDED               Shared library: [libX11.so.6]
 0x00000001 NEEDED               Shared library: [libc++.so.1]
 0x00000001 NEEDED               Shared library: [libc.so.7]
 0x00000001 NEEDED               Shared library: [libcxxrt.so.1]
 0x00000001 NEEDED               Shared library: [libgcc_s.so.1]
 0x00000001 NEEDED               Shared library: [libm.so.5]
 0x00000001 NEEDED               Shared library: [libthr.so.3]
 0x00000001 NEEDED               Shared library: [libva-drm.so.2]
 0x00000001 NEEDED               Shared library: [libva-wayland.so.2]
 0x00000001 NEEDED               Shared library: [libva-x11.so.2]
 0x00000001 NEEDED               Shared library: [libva.so.2]
 0x00000001 NEEDED               Shared library: [libwayland-client.so.0]
```
