### PR TITLE
Ifdef va_x11 in VP sample for usrptr

### DIFF
--- a/videoprocess/vppscaling_n_out_usrptr.cpp
+++ b/videoprocess/vppscaling_n_out_usrptr.cpp
@@ -38,7 +38,9 @@
 #include <va/va.h>
 #include <va/va_vpp.h>
 #include "va_display.h"
+#if 0
 #include <va/va_x11.h>
+#endif
 
 #define MAX_LEN   1024
 


### PR DESCRIPTION
When updating libva-utils from 2.4.0 to 2.6.0 in Chrome OS I bumped into
the following error:
```
portage/media-video/libva-utils-2.6.0-r1/work/libva-utils-2.6.0/videoprocess/vppscaling_n_out_usrptr.cpp:41:10: fatal error:
      'va/va_x11.h' file not found
```

Signed-off-by: Edward Baker <edward.baker@intel.com>