### PR TITLE
Fixes for GCC 10.0.1 compiler errors

### DIFF
--- a/test/test.h
+++ b/test/test.h
@@ -142,7 +142,7 @@ public:
             status = "VA_STATUS_ERROR_HW_BUSY"; break;
         case VA_STATUS_ERROR_UNSUPPORTED_MEMORY_TYPE:
             status = "VA_STATUS_ERROR_UNSUPPORTED_MEMORY_TYPE"; break;
-        case VA_STATUS_ERROR_UNKNOWN:
+        case VAStatus(VA_STATUS_ERROR_UNKNOWN):
             status = "VA_STATUS_ERROR_UNKNOWN"; break;
         default:
             status = "Unknown VAStatus";

--- a/test/test_va_api_fixture.cpp
+++ b/test/test_va_api_fixture.cpp
@@ -39,7 +39,6 @@ VAAPIFixture::VAAPIFixture()
     , m_vaDisplay(NULL)
     , m_restoreDriverName(getenv("LIBVA_DRIVER_NAME"))
     , m_drmHandle(-1)
-    , drmDevicePaths({ "/dev/dri/renderD128", "/dev/dri/card0" })
     , m_configID(VA_INVALID_ID)
     , m_contextID(VA_INVALID_ID)
     , m_bufferID(VA_INVALID_ID)
@@ -73,10 +72,14 @@ VAAPIFixture::~VAAPIFixture()
 
 VADisplay VAAPIFixture::getDisplay()
 {
-    uint32_t i;
+    typedef std::vector<std::string> DevicePaths;
+    typedef DevicePaths::const_iterator DevicePathsIterator;
 
-    for (i = 0; i < sizeof(drmDevicePaths) / sizeof(*drmDevicePaths); i++) {
-        m_drmHandle = open(drmDevicePaths[i].c_str(), O_RDWR);
+    static DevicePaths paths({"/dev/dri/renderD128", "/dev/dri/card0"});
+
+    const DevicePathsIterator endIt(paths.end());
+    for (DevicePathsIterator it(paths.begin()); it != endIt; ++it) {
+        m_drmHandle = open(it->c_str(), O_RDWR);
         if (m_drmHandle < 0)
             continue;
         m_vaDisplay = vaGetDisplayDRM(m_drmHandle);

--- a/test/test_va_api_fixture.h
+++ b/test/test_va_api_fixture.h
@@ -102,7 +102,6 @@ protected:
 private:
     char *m_restoreDriverName;
     int m_drmHandle;
-    const std::string drmDevicePaths[2];
 
     VAConfigID m_configID;
     VAContextID m_contextID;


### PR DESCRIPTION
Fixes for several compiler errors generated in the C++ code in the test directory.

Fixes #191 

These patches should be included in the next upcoming release.