### PR TITLE
Add FreeBSD to TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,23 @@ script:
   - make -j4 ; sudo make install
   - make check
 
+jobs:
+  include:
+    - os: linux
+    - os: freebsd
+      compiler: clang
+      before_install:
+        - sudo pkg install -y meson pkgconf libdrm libXext libXfixes wayland
+        - sudo pkg install -y -x '^mesa($|-libs)'
+      install:
+        - sudo ln -sf /usr/local/libdata/pkgconfig /usr/local/lib/
+        - git clone https://github.com/intel/libva.git
+        - (cd libva && meson _build && meson compile -C _build && sudo meson install -C _build)
+      script:
+        - meson _build
+        - meson compile -C _build
+      after_success: skip
+
 after_success:
         - coveralls --exclude lib --exclude tests --gcov-options '\-lp'
 


### PR DESCRIPTION
Depends on https://github.com/intel/libva/pull/363. Tests are not built yet due to https://github.com/intel/libva-utils/issues/186.

Downstream comparison:
- meson: Alpine, Arch, Carbs, Exherbo, FreeBSD, Nix, OpenMandriva, Slackware, Void
- autotools: Fedora, Debian, Gentoo, PkgSrc