### PR TITLE
Print more attrib info for debug

### DIFF
--- a/test/test_va_api_fixture.cpp
+++ b/test/test_va_api_fixture.cpp
@@ -228,7 +228,7 @@ void VAAPIFixture::createConfig(const VAProfile& profile,
             attribs.size(), &m_configID))
         << "profile    = " << profile << std::endl
         << "entrypoint = " << entrypoint << std::endl
-        << "numAttribs = " << attribs.size();
+        << "Attribs    = " << attribs.data();
 
     if (expectation == VA_STATUS_SUCCESS) {
         EXPECT_ID(m_configID);


### PR DESCRIPTION
print attrib type and value when failue,could improve debug
effiency.

Signed-off-by: Shawn Li <shawn.li@intel.com>