### PR TITLE
remove version check for test vaInitialize_vaTerminate

### DIFF
--- a/test/test_va_api_init_terminate.cpp
+++ b/test/test_va_api_init_terminate.cpp
@@ -42,8 +42,7 @@ protected:
 
         EXPECT_EQ(VA_MAJOR_VERSION, major)
             << "Check installed driver version";
-
-        EXPECT_EQ(VA_MINOR_VERSION, minor)
+        EXPECT_LE(VA_MINOR_VERSION, minor)
             << "Check installed driver version";
 
         ASSERT_STATUS(vaTerminate(display));


### PR DESCRIPTION
it is used to fix such issue, version from libva-utils and libva is different.
because older libva-utils should also work with newer libva.

Signed-off-by: Carl Zhang <carl.zhang@intel.com>