### PR TITLE
ci: fix freebsd build

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   freebsd:
-    runs-on: macos-latest
+    runs-on: macos-10.15
     steps:
     - name: checkout libva
       uses: actions/checkout@v2
@@ -24,7 +24,7 @@ jobs:
       with:
         path: libva-utils
     - name: test
-      uses: vmactions/freebsd-vm@v0.1.3
+      uses: vmactions/freebsd-vm@v0.1.5
       with:
         prepare: |
           pkg install -y meson pkgconf libdrm libXext libXfixes wayland
@@ -32,7 +32,7 @@ jobs:
         run: |
           set PREFIX="$PWD/_install"
           set LIBDIR="$PREFIX/lib"
-          setenv PKG_CONFIG_PATH $LIBDIR/pkgconfig
+          setenv PKG_CONFIG_PATH $LIBDIR/pkgconfig:$PREFIX/libdata/pkgconfig
           cd libva
           meson --prefix=$PREFIX --libdir=$LIBDIR _build
           meson compile -C _build


### PR DESCRIPTION
Switching to:
* vmactions/freebsd-vm@v0.1.5 to fetch FreeBSD 13
* macos-10.15

It seems github systems are getting updates with later macos
versions (11.6.1) which don't have vboxmanage required to run VMs.

Signed-off-by: Dmitry Rogozhkin <dmitry.v.rogozhkin@intel.com>