### PR TITLE
exclude vgem node and invalid drm node in vainfo

### DIFF
--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -41,7 +41,7 @@ endif
 
 if USE_DRM
 source_c		+= va_display_drm.c
-libva_display_cflags	+= $(DRM_CFLAGS) $(LIBVA_DRM_CFLAGS)
+libva_display_cflags	+= $(DRM_CFLAGS) $(LIBVA_DRM_CFLAGS) $(DRM_CFLAGS)
 libva_display_libs	+= $(DRM_LIBS) $(LIBVA_DRM_LIBS)
 endif
 

--- a/configure.ac
+++ b/configure.ac
@@ -144,6 +144,7 @@ AM_CONDITIONAL(USE_SSP, test "$ssp_cc" = "yes")
 
 # Check for DRM (mandatory)
 PKG_CHECK_MODULES([LIBVA_DRM], [libva-drm])
+PKG_CHECK_MODULES([DRM], [libdrm])
 
 # Check for libva (for dynamic linking)
 LIBVA_API_MIN_VERSION=libva_api_min_version

--- a/meson.build
+++ b/meson.build
@@ -21,6 +21,7 @@ if get_option('drm') != 'false'
   require_drm = get_option('drm') == 'true'
   drm_deps = [
     dependency('libva-drm', required: require_drm),
+    dependency('drm', required: require_drm),
   ]
   use_drm = true
   foreach d : drm_deps


### PR DESCRIPTION
call drm function to avoid invalid node
check the name of vgem

Signed-off-by: Carl Zhang <carl.zhang@intel.com>