### PR TITLE
avcenc: Use the appropriate size for VAEncMiscParameterHRD

### DIFF
--- a/encode/avcenc.c
+++ b/encode/avcenc.c
@@ -851,7 +851,7 @@ static int begin_picture(FILE *yuv_fp, int frame_num, int display_num, int slice
     vaCreateBuffer(va_dpy,
                    avcenc_context.context_id,
                    VAEncMiscParameterBufferType,
-                   sizeof(VAEncMiscParameterBuffer) + sizeof(VAEncMiscParameterRateControl),
+                   sizeof(VAEncMiscParameterBuffer) + sizeof(VAEncMiscParameterHRD),
                    1,
                    NULL,
                    &avcenc_context.misc_parameter_hrd_buf_id);


### PR DESCRIPTION
This buffer's size should the one of the VAEncMiscParameterHRD structure,
not the VAEncMiscParameterRateControl.

Signed-off-by: Carlos Falgueras García <cfalgueras@fluendo.com>