### PR TITLE
[Decode] Components exceed the value specified by Jpeg spec

### DIFF
--- a/decode/tinyjpeg-internal.h
+++ b/decode/tinyjpeg-internal.h
@@ -87,7 +87,7 @@ struct jpeg_sos {
         unsigned int component_id;
         unsigned int dc_selector;
         unsigned int ac_selector;
-    } components[4];
+    } components[COMPONENTS];
 };
 
 struct jdec_private {

--- a/decode/tinyjpeg.c
+++ b/decode/tinyjpeg.c
@@ -277,7 +277,8 @@ static int parse_SOS(struct jdec_private *priv, const unsigned char *stream)
 {
     unsigned int i, cid, table;
     unsigned int nr_components = stream[2];
-
+    if(nr_components > COMPONENTS)
+        error("Components exceed the value specified by the Jpeg spec\n");
     trace("> SOS marker\n");
 
     priv->cur_sos.nr_components = nr_components;


### PR DESCRIPTION
jpeg components number should not exceed 4 following the spec

Signed-off-by: Liu, Chuan1 <chuan1.liu@intel.com>