### PR TITLE
meson: Search for libdrm

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -21,7 +21,7 @@ if get_option('drm') != 'false'
   require_drm = get_option('drm') == 'true'
   drm_deps = [
     dependency('libva-drm', required: require_drm),
-    dependency('drm', required: require_drm),
+    dependency('libdrm', required: require_drm),
   ]
   use_drm = true
   foreach d : drm_deps


### PR DESCRIPTION
The pkgconfig file is named 'libdrm', as can be seen in configure.ac,
not 'drm'.

Fixes: bfb6b98 ("exclude vgem node and invalid drm node in vainfo")

Cc: @XinfengZhang