### PR TITLE
meson: Search for threads in top-level meson.build

### DIFF
--- a/encode/meson.build
+++ b/encode/meson.build
@@ -1,4 +1,3 @@
-threads = dependency('threads')
 m = c.find_library('m')
 
 

--- a/meson.build
+++ b/meson.build
@@ -10,6 +10,8 @@ project('libva-utils', 'c', 'cpp',
 
 c = meson.get_compiler('c')
 
+threads = dependency('threads')
+
 libva_dep = dependency('libva', version: '>= 1.1.0')
 
 libva_utils_flags = [ '-Wno-unused-parameter',


### PR DESCRIPTION
In Gentoo we allow disabling the tools and putsuface separately, so
moving the threads check out of the encode subdirectory helps.

Cc: @XinfengZhang 