### PR TITLE
common: print the display being attempted

### DIFF
--- a/common/va_display.c
+++ b/common/va_display.c
@@ -151,6 +151,7 @@ va_open_display(void)
             continue;
         if (!g_display_hooks->open_display)
             continue;
+        printf("Trying display: %s\n", g_display_hooks->name);
         va_dpy = g_display_hooks->open_display();
     }
 


### PR DESCRIPTION
Currently we silently fall-though all possible display types. Which is
fairly confusing for the end user if `vainfo` works but it fails on
their favourite program.

Add an explicit print, saving time to both users and developers.
