### PR TITLE
CheckEntrypointsForProfile test failed if MPEG2Simple is not suported

### DIFF
--- a/test/test_va_api_query_config.cpp
+++ b/test/test_va_api_query_config.cpp
@@ -50,6 +50,8 @@ TEST_P(VAAPIQueryConfig, CheckEntrypointsForProfile)
     EXPECT_TRUE(numProfiles > 0)
             << numProfiles << " profiles are supported by driver";
 
+    profiles.resize(numProfiles);
+
     const int maxEntrypoints = vaMaxNumEntrypoints(m_vaDisplay);
     EXPECT_TRUE(maxEntrypoints > 0)
             << maxEntrypoints << " entrypoints are reported";


### PR DESCRIPTION
VAAPI driver may support less profiles than specified in max_profiles. In this case, elements in profiles vector above the numProfiles have default value (0 or VAProfileMPEG2Simple) and test fails if this profile is not supported.