### PR TITLE
test_va_api: Don't assume our DRM node is first

### DIFF
--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -41,8 +41,8 @@ endif
 
 if USE_DRM
 source_c		+= va_display_drm.c
-libva_display_cflags	+= $(DRM_CFLAGS) $(LIBVA_DRM_CFLAGS) $(DRM_CFLAGS)
-libva_display_libs	+= $(DRM_LIBS) $(LIBVA_DRM_LIBS)
+libva_display_cflags	+= $(LIBVA_DRM_CFLAGS)
+libva_display_libs	+= $(LIBVA_DRM_LIBS)
 endif
 
 if USE_WAYLAND

--- a/configure.ac
+++ b/configure.ac
@@ -143,8 +143,7 @@ fi
 AM_CONDITIONAL(USE_SSP, test "$ssp_cc" = "yes")
 
 # Check for DRM (mandatory)
-PKG_CHECK_MODULES([LIBVA_DRM], [libva-drm])
-PKG_CHECK_MODULES([DRM], [libdrm])
+PKG_CHECK_MODULES([LIBVA_DRM], [libva-drm libdrm])
 
 # Check for libva (for dynamic linking)
 LIBVA_API_MIN_VERSION=libva_api_min_version


### PR DESCRIPTION
Similar to:

bfb6b98ed62a exclude vgem node and invalid drm node in vainfo

It's possible to have a vgem node at 128, and the VA-API node is at 129.

Signed-off-by: Brian Norris <briannorris@chromium.org>