### PR TITLE
test/test_va_api_query_config: Changed default initialization value t…

### DIFF
--- a/test/test_va_api_query_config.cpp
+++ b/test/test_va_api_query_config.cpp
@@ -42,7 +42,7 @@ TEST_P(VAAPIQueryConfig, CheckEntrypointsForProfile)
     EXPECT_TRUE(maxProfiles > 0)
             << maxProfiles << " profiles are reported";
 
-    Profiles profiles(maxProfiles);
+    Profiles profiles(maxProfiles, VAProfileNone);
 
     EXPECT_STATUS(
         vaQueryConfigProfiles(m_vaDisplay, profiles.data(), &numProfiles));


### PR DESCRIPTION
…o VAProfileNone

In Vaapi unit test VAAPIQueryConfig, CheckEntrypointsForProfile the default initialization value has  been changed from zero to VAProfileNone as zero is a valid profile matches with MPEG2Simple and this unit test misinterpret it as part of return value from vaQueryConfigProfiles

Signed-off-by: Himanshu Nayak <himanshu.nayak@amd.corp-partner.google.com>