### PR TITLE
Correct maximum display luminance per VAAPI definition.

### DIFF
--- a/videoprocess/process_hdr_tm_h2h.cfg.template
+++ b/videoprocess/process_hdr_tm_h2h.cfg.template
@@ -8,41 +8,41 @@
 # filter and the corresponding parameters.
 
 #To simplify this test app, we use the default gamut for both source and destination.
-#Please set correct gamut according to the real value.
-#BT2020    Gammut	  Multiplier		Output	
-#G	0.17	  0.797		   50000		    8500	39850
-#R	0.708	  0.292		   50000		    35400	14600
-#B	0.131	  0.046		   50000		    6550	2300
-#w	0.3127	0.329		   50000		    15635	16450
-#BT709    Gammut	  Multiplier		Output	
-#G	0.3	0.6		50000		15000	30000
-#R	0.64	0.33		50000		32000	16500
-#B	0.15	0.06		50000		7500	3000
-#w	0.3127	0.329		50000		15635	16450
+#Please set correct gamut according to the real value and VAAPI definition.
+#BT2020    Gammut        Multiplier        Output
+#G          0.17          0.797            50000        8500      39850
+#R          0.708         0.292            50000        35400     14600
+#B          0.131         0.046            50000        6550      2300
+#w          0.3127        0.329            50000        15635     16450
+#BT709    Gammut         Multiplier       Output
+#G          0.3           0.6              50000        15000     30000
+#R          0.64          0.33             50000        32000     16500
+#B          0.15          0.06             50000        7500      3000
+#w          0.3127        0.329            50000        15635     16450
 
 #0. Tone Map Type: 0-H2H, 1-H2E, 2-H2S
 TM_TYPE: 0
 
 #1.Source YUV(RGB) file information
-SRC_FILE_NAME: ShowGirl2Teaser_1920x1080_4000nits.p010
+SRC_FILE_NAME: Source_1920x1080_4000nits.p010
 SRC_FRAME_WIDTH: 1920 
 SRC_FRAME_HEIGHT: 1080
 SRC_FRAME_FORMAT: P010
 SRC_FRAME_COLOUR_PRIMARIES: 9
 SRC_FRAME_TRANSFER_CHARACTERISTICS: 16
-SRC_MAX_DISPLAY_MASTERING_LUMINANCE: 1000
+SRC_MAX_DISPLAY_MASTERING_LUMINANCE: 10000000
 SRC_MIN_DISPLAY_MASTERING_LUMINANCE: 100
 SRC_MAX_CONTENT_LIGHT_LEVEL: 4000
 SRC_MAX_PICTURE_AVERAGE_LIGHT_LEVEL: 100
 
 #2.Destination YUV(RGB) file information
-DST_FILE_NAME:    ShowGirl2Teaser_1920x1080_1000nits_writer.a2rgb10
+DST_FILE_NAME:    Dest_1920x1080_1000nits_writer.p010
 DST_FRAME_WIDTH:  1920
 DST_FRAME_HEIGHT: 1080
-DST_FRAME_FORMAT: A2RGB10
+DST_FRAME_FORMAT: P010
 DST_FRAME_COLOUR_PRIMARIES: 9
 DST_FRAME_TRANSFER_CHARACTERISTICS: 16
-DST_MAX_DISPLAY_MASTERING_LUMINANCE: 1000
+DST_MAX_DISPLAY_MASTERING_LUMINANCE: 10000000
 DST_MIN_DISPLAY_MASTERING_LUMINANCE: 100
 DST_MAX_CONTENT_LIGHT_LEVEL: 1000
 DST_MAX_PICTURE_AVERAGE_LIGHT_LEVEL: 100

--- a/videoprocess/process_hdr_tm_h2s.cfg.template
+++ b/videoprocess/process_hdr_tm_h2s.cfg.template
@@ -8,43 +8,42 @@
 # filter and the corresponding parameters.
 
 #To simplify this test app, we use the default gamut for both source and destination.
-#Please set correct gamut according to the real value.
-#BT2020    Gammut	  Multiplier		Output	
-#G	0.17	  0.797		   50000		    8500	39850
-#R	0.708	  0.292		   50000		    35400	14600
-#B	0.131	  0.046		   50000		    6550	2300
-#w	0.3127	0.329		   50000		    15635	16450
-#BT709    Gammut	  Multiplier		Output	
-#G	0.3	0.6		50000		15000	30000
-#R	0.64	0.33		50000		32000	16500
-#B	0.15	0.06		50000		7500	3000
-#w	0.3127	0.329		50000		15635	16450
+#Please set correct gamut according to the real value and VAAPI definition.
+#BT2020    Gammut        Multiplier        Output
+#G          0.17          0.797            50000        8500      39850
+#R          0.708         0.292            50000        35400     14600
+#B          0.131         0.046            50000        6550      2300
+#w          0.3127        0.329            50000        15635     16450
+#BT709    Gammut         Multiplier       Output
+#G          0.3           0.6              50000        15000     30000
+#R          0.64          0.33             50000        32000     16500
+#B          0.15          0.06             50000        7500      3000
+#w          0.3127        0.329            50000        15635     16450
 
 #0. Tone Map Type: 0-H2H, 1-H2E, 2-H2S
 TM_TYPE: 2
 
 #1.Source YUV(RGB) file information
-SRC_FILE_NAME: ShowGirl2Teaser_1920x1080_4000nits.p010
+SRC_FILE_NAME: Source_1920x1080_4000nits.p010
 SRC_FRAME_WIDTH: 1920
 SRC_FRAME_HEIGHT: 1080
 SRC_FRAME_FORMAT: P010
 SRC_FRAME_COLOUR_PRIMARIES: 9
 SRC_FRAME_TRANSFER_CHARACTERISTICS: 16
-SRC_MAX_DISPLAY_MASTERING_LUMINANCE: 1000
+SRC_MAX_DISPLAY_MASTERING_LUMINANCE: 10000000
 SRC_MIN_DISPLAY_MASTERING_LUMINANCE: 100
 SRC_MAX_CONTENT_LIGHT_LEVEL: 4000
 SRC_MAX_PICTURE_AVERAGE_LIGHT_LEVEL: 100
 
 #2.Destination YUV(RGB) file information
-DST_FILE_NAME:    ShowGirl2Teaser_1920x1080_4000nits_writer.argb
+DST_FILE_NAME:    Dest_1920x1080_4000nits_writer.argb
 DST_FRAME_WIDTH:  1920
 DST_FRAME_HEIGHT: 1080
 DST_FRAME_FORMAT: RGBA
-DST_FRAME_COLOUR_PRIMARIES: 9
-DST_FRAME_TRANSFER_CHARACTERISTICS: 1
-DST_MAX_DISPLAY_MASTERING_LUMINANCE: 1000
+DST_FRAME_COLOUR_PRIMARIES: 1
+DST_MAX_DISPLAY_MASTERING_LUMINANCE: 1000000
 DST_MIN_DISPLAY_MASTERING_LUMINANCE: 100
-DST_MAX_CONTENT_LIGHT_LEVEL: 1000
+DST_MAX_CONTENT_LIGHT_LEVEL: 100
 DST_MAX_PICTURE_AVERAGE_LIGHT_LEVEL: 100
 
 #3.How many frames to be processed

--- a/videoprocess/vpphdr_tm.cpp
+++ b/videoprocess/vpphdr_tm.cpp
@@ -74,12 +74,14 @@ static uint32_t g_src_file_fourcc = VA_FOURCC('I', '4', '2', '0');
 static uint32_t g_dst_file_fourcc = VA_FOURCC('Y', 'V', '1', '2');
 
 static uint32_t g_frame_count = 1;
-static uint32_t g_in_max_display_luminance = 1000;
-static uint32_t g_in_min_display_luminance = 1;
+// The maximum display luminace is 1000 nits by default.
+static uint32_t g_in_max_display_luminance = 10000000;
+static uint32_t g_in_min_display_luminance = 100;
 static uint32_t g_in_max_content_luminance = 4000;
 static uint32_t g_in_pic_average_luminance = 1000;
-static uint32_t g_out_max_display_luminance = 1000;
-static uint32_t g_out_min_display_luminance = 1;
+// The maximum display luminace is 1000 nits by default.
+static uint32_t g_out_max_display_luminance = 10000000;
+static uint32_t g_out_min_display_luminance = 100;
 static uint32_t g_out_max_content_luminance = 4000;
 static uint32_t g_out_pic_average_luminance = 1000;
 
@@ -667,13 +669,13 @@ bool write_surface_to_frame(FILE *fp, VASurfaceID surface_id)
         y_src = (unsigned char*)in_buf + va_image.offsets[0];
         u_src = (unsigned char*)in_buf + va_image.offsets[1]; // U offset for P010                                                        
         for (i = 0; i < va_image.height; i++)  {
-            memcpy(y_dst, y_src, va_image.width * 2);
-            y_dst += va_image.width * 2;
+            memcpy(y_dst, y_src, va_image.width * bytes_per_pixel);
+            y_dst += va_image.width * bytes_per_pixel;
             y_src += va_image.pitches[0];
         }
         for (i = 0; i < va_image.height >> 1; i++)  {
-            memcpy(u_dst, u_src, va_image.width * 2);
-            u_dst += va_image.width * 2;
+            memcpy(u_dst, u_src, va_image.width * bytes_per_pixel);
+            u_dst += va_image.width * bytes_per_pixel;
             u_src += va_image.pitches[1];
         }
         printf("read_frame_to_surface: P010 \n");


### PR DESCRIPTION
VAAPI defines the maximum display luminance as in the unit of 0.0001nits.

Signed-off-by: Furong Zhang <furong.zhang@intel.com>