### PR TITLE
Fixed memory leak

### DIFF
--- a/encode/h264encode.c
+++ b/encode/h264encode.c
@@ -1165,6 +1165,7 @@ static int init_va(void)
     /* check the interested configattrib */
     if ((attrib[VAConfigAttribRTFormat].value & VA_RT_FORMAT_YUV420) == 0) {
         printf("Not find desired YUV420 RT format\n");
+	free(entrypoints);
         exit(1);
     } else {
         config_attrib[config_attrib_num].type = VAConfigAttribRTFormat;

--- a/vendor/intel/sfcsample/VDecAccelVA.cpp
+++ b/vendor/intel/sfcsample/VDecAccelVA.cpp
@@ -586,6 +586,9 @@ bool mvaccel::VDecAccelVAImpl::DecodePicture()
         fwrite(gfx_surface_buf, file_size, 1, sfc_stream);
         fclose(sfc_stream);
     }
+    else {
+        printf("Fail to open sfc_sample_176_144_argb.yuv file for writing\n");
+    }
 
     //unlock surface and clear
     unlock_surface(m_sfcIDs[0]);


### PR DESCRIPTION
Fixed possible memory leak by freeing entrypoints before the exit statement as opened in issue #182.