### PR TITLE
Handling failure condition in writing to yuv file

### DIFF
--- a/vendor/intel/sfcsample/VDecAccelVA.cpp
+++ b/vendor/intel/sfcsample/VDecAccelVA.cpp
@@ -586,6 +586,9 @@ bool mvaccel::VDecAccelVAImpl::DecodePicture()
         fwrite(gfx_surface_buf, file_size, 1, sfc_stream);
         fclose(sfc_stream);
     }
+    else {
+	printf("Fail to open sfc_sample_176_144_argb.yuv for writing\n");
+    }
 
     //unlock surface and clear
     unlock_surface(m_sfcIDs[0]);


### PR DESCRIPTION
Adding 'else' condition if sfc_stream is unable to open the file for writing, in reference to issue #181.

Signed-off-by: Shekhar Chauhan <shekhar.chauhan@intel.com>