### PR TITLE
libva-xyz should be same version as detected libva

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -142,9 +142,6 @@ if test "X$CC-cc" != "X"; then
 fi
 AM_CONDITIONAL(USE_SSP, test "$ssp_cc" = "yes")
 
-# Check for DRM (mandatory)
-PKG_CHECK_MODULES([LIBVA_DRM], [libva-drm libdrm])
-
 # Check for libva (for dynamic linking)
 LIBVA_API_MIN_VERSION=libva_api_min_version
 PKG_CHECK_MODULES([LIBVA], [libva >= $LIBVA_API_MIN_VERSION])
@@ -155,7 +152,8 @@ VA_MAJOR_VERSION=`echo "$LIBVA_API_VERSION" | cut -d'.' -f1`
 VA_MINOR_VERSION=`echo "$LIBVA_API_VERSION" | cut -d'.' -f2`
 VA_MICRO_VERSION=`echo "$LIBVA_API_VERSION" | cut -d'.' -f3`
 
-
+# Check for DRM (mandatory)
+PKG_CHECK_MODULES([LIBVA_DRM], [libdrm libva-drm = $LIBVA_API_VERSION])
 
 USE_DRM="no"
 if test "$enable_drm" = "yes"; then
@@ -167,7 +165,7 @@ AM_CONDITIONAL(USE_DRM, test "$USE_DRM" = "yes")
 # Check for X11
 USE_X11="no"
 if test "x$enable_x11" != "xno"; then
-    PKG_CHECK_MODULES([X11],    [x11 libva-x11],
+    PKG_CHECK_MODULES([X11],    [x11 libva-x11 = $LIBVA_API_VERSION],
         [USE_X11="yes"], [:])
 
     if test "x$USE_X11" = "xno" -a "x$enable_x11" = "xyes"; then
@@ -186,7 +184,7 @@ AC_SUBST(WAYLAND_API_VERSION)
 
 USE_WAYLAND="no"
 if test "x$enable_wayland" != "xno"; then
-    PKG_CHECK_MODULES([WAYLAND], [wayland-client >= wayland_api_version libva-wayland],
+    PKG_CHECK_MODULES([WAYLAND], [wayland-client >= wayland_api_version libva-wayland = $LIBVA_API_VERSION],
         [USE_WAYLAND="yes"], [:])
 
     if test "x$USE_WAYLAND" = "xno" -a "x$enable_wayland" = "xyes"; then

--- a/meson.build
+++ b/meson.build
@@ -25,7 +25,7 @@ drm_deps=[]
 if get_option('drm') != 'false'
   require_drm = get_option('drm') == 'true'
   drm_deps = [
-    dependency('libva-drm', required: require_drm),
+    dependency('libva-drm', version: libva_dep.version(), required: require_drm),
     dependency('libdrm', required: require_drm),
   ]
   use_drm = true
@@ -46,7 +46,7 @@ if get_option('x11') != 'false'
   require_x11 = get_option('x11') == 'true'
   x11_deps = [
     dependency('x11', required: require_x11),
-    dependency('libva-x11', required: require_x11),
+    dependency('libva-x11', version: libva_dep.version(), required: require_x11),
   ]
   use_x11 = true
   foreach d : x11_deps
@@ -66,7 +66,7 @@ if get_option('wayland') != 'false'
   require_wayland = get_option('wayland') == 'true'
   wayland_deps = [
     dependency('wayland-client', version: '>= 1.0.0', required: require_wayland),
-    dependency('libva-wayland', required: require_wayland),
+    dependency('libva-wayland', version: libva_dep.version(), required: require_wayland),
   ]
   use_wayland = true
   foreach d : wayland_deps
@@ -84,7 +84,7 @@ endif
 use_win32 = false
 if get_option('win32') != 'false'
   require_win32 = get_option('win32') == 'true'
-  use_win32 = dependency('libva-win32', required: require_win32).found()
+  use_win32 = dependency('libva-win32', version: libva_dep.version(), required: require_win32).found()
   if use_win32
     libva_utils_flags = [ '-DHAVE_VA_WIN32=1', '-DNOMINMAX']
     dep_dxheaders = dependency('directx-headers', required : false)


### PR DESCRIPTION
This will help prevent erroneous linking to mixed versions of libva-xyz window system libraries that may not be binary compatible.  For example,
 1. User installs libva-dev from distro packages that provides all libva-xyz.pc/.so window system libraries.
 2. Then, user compiles and installs libva from source with 1 or more [auto] disabled libva-xyz window system libraries.
 3. Finally, user compiles libva-utils from source, but configure finds a mix of distro installed and user compiled libva-xyz window system libraries and encounters linker error when not binary compatible with user installed libva.so.