### PR TITLE
meson: guard code introduced after libva 1.10 release

### DIFF
--- a/encode/meson.build
+++ b/encode/meson.build
@@ -24,6 +24,8 @@ executable('vp9enc', [ 'vp9enc.c' ],
 executable('vp8enc', [ 'vp8enc.c' ],
            dependencies: [libva_display_dep, threads, m ],
            install: true)
-executable('av1encode', [ 'av1encode.c' ],
-           dependencies: [ libva_display_dep, threads, m ],
-           install: true)
+if libva_dep.version().version_compare('>= 1.14.0')
+    executable('av1encode', [ 'av1encode.c' ],
+            dependencies: [ libva_display_dep, threads, m ],
+            install: true)
+endif

--- a/videoprocess/meson.build
+++ b/videoprocess/meson.build
@@ -4,9 +4,11 @@ executable('vacopy', [ 'vacopy.cpp' ],
 executable('vavpp', [ 'vavpp.cpp' ],
            dependencies: libva_display_dep,
            install: true)
-executable('vpp3dlut', [ 'vpp3dlut.cpp' ],
-           dependencies: libva_display_dep,
-           install: true)
+if libva_dep.version().version_compare('>= 1.12.0')
+    executable('vpp3dlut', [ 'vpp3dlut.cpp' ],
+            dependencies: libva_display_dep,
+            install: true)
+endif
 executable('vppblending', [ 'vppblending.cpp' ],
            dependencies: libva_display_dep,
            install: true)


### PR DESCRIPTION
Closes: https://github.com/intel/libva-utils/issues/328

Tested inside the Mesa3D CI running on Debian 11 (bullseye). Build and runtime working perfectly with latest libva-utils with this MR.