### PR TITLE
av1encode: simplify cbr/vbr interface and refine codes

### DIFF
--- a/encode/av1encode.c
+++ b/encode/av1encode.c
@@ -680,7 +680,7 @@ static void process_cmdline(int argc, char *argv[])
     };
 
     int long_index;
-    while ((c = getopt_long_only(argc, argv, "n:f:o:?", long_opts, &long_index)) != EOF)
+    while ((c = getopt_long_only(argc, argv, "n:f:o:t:m:u:d:?", long_opts, &long_index)) != EOF)
     {
         switch (c) 
         {


### PR DESCRIPTION
1. Unify bitrate interface and remove buffer size related settings to
   use driver default values for best quality.
2. Remove extra empty lines for refining code.

Signed-off-by: Xue, Maxim <maxim.xue@intel.com>