### PR TITLE
ci: update freebsd vm to the v1 version

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   freebsd:
-    runs-on: macos-12
+    runs-on: ubuntu-latest
     steps:
     - name: checkout libva
       uses: actions/checkout@v3
@@ -24,7 +24,7 @@ jobs:
       with:
         path: libva-utils
     - name: test
-      uses: vmactions/freebsd-vm@v0
+      uses: vmactions/freebsd-vm@v1
       with:
         prepare: |
           pkg install -y meson pkgconf libdrm libXext libXfixes wayland


### PR DESCRIPTION
The previous v0 is not working anymore.
Update to use the latest v1 version.
