### PR TITLE
[Encode] Fix some coverity issues exposed in encode

### DIFF
--- a/encode/av1encode.c
+++ b/encode/av1encode.c
@@ -2900,9 +2900,9 @@ static int calc_PSNR(double *psnr)
             srcyuv_ptr = mmap(0, fourM, PROT_READ, MAP_SHARED, fileno(srcyuv_fp), i);
             recyuv_ptr = mmap(0, fourM, PROT_READ, MAP_SHARED, fileno(recyuv_fp), i);
             if ((srcyuv_ptr == MAP_FAILED) || (recyuv_ptr == MAP_FAILED)) {
-                if (srcyuv_ptr) 
+                if (srcyuv_ptr != MAP_FAILED) 
                     munmap(srcyuv_ptr, fourM);
-                if (recyuv_ptr) 
+                if (recyuv_ptr != MAP_FAILED) 
                     munmap(recyuv_ptr, fourM);
                 printf("Failed to mmap YUV files\n");
                 return 1;

--- a/encode/avcenc.c
+++ b/encode/avcenc.c
@@ -2117,7 +2117,12 @@ int main(int argc, char *argv[])
     file_size = ftello(yuv_fp);
     frame_size = picture_width * picture_height + ((picture_width * picture_height) >> 1) ;
 
-    if ((file_size < frame_size) || ((frame_size != 0) && (file_size % frame_size))) {
+    if (frame_size == 0) {
+        fclose(yuv_fp);
+        printf("Frame size is not correct\n");
+        return -1;
+    }
+    if ((file_size < frame_size) || (file_size % frame_size)) {
         fclose(yuv_fp);
         printf("The YUV file's size is not correct\n");
         return -1;

--- a/encode/vp9enc.c
+++ b/encode/vp9enc.c
@@ -1541,7 +1541,12 @@ main(int argc, char *argv[])
     file_size = ftello(yuv_fp);
     frame_size = picture_width * picture_height + ((picture_width * picture_height) >> 1) ;
 
-    if ((file_size < frame_size) || ((frame_size != 0) && (file_size % frame_size))) {
+    if (frame_size == 0) {
+        fclose(yuv_fp);
+        printf("Frame size is not correct\n");
+        return -1;
+    }
+    if ((file_size < frame_size) || (file_size % frame_size)) {
         fclose(yuv_fp);
         printf("The YUV file's size is not correct\n");
         return -1;


### PR DESCRIPTION
Fix some remaining encode coverity issues: 1 Unchecked return value; 1 Resource leak; 2 Modulo by zero

Signed-off-by: Chen, Bohan <bohan.chen@intel.com>