### PR TITLE
ci: update freebsd vm to the v1 version

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: checkout libva
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: intel/libva
         path: libva
     - name: checkout libva-utils
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         path: libva-utils
     - name: test
@@ -30,14 +30,11 @@ jobs:
           pkg install -y meson pkgconf libdrm libXext libXfixes wayland
           pkg install -y -x '^mesa($|-libs)'
         run: |
-          set PREFIX="$PWD/_install"
-          set LIBDIR="$PREFIX/lib"
-          setenv PKG_CONFIG_PATH $LIBDIR/pkgconfig:$PREFIX/libdata/pkgconfig
           cd libva
-          meson --prefix=$PREFIX --libdir=$LIBDIR _build
+          meson setup _build --prefix=/usr --libdir=/usr/lib/x86_64-linux-gnu
           meson compile -C _build
           meson install -C _build
           cd ../libva-utils
-          meson --prefix=$PREFIX --libdir=$LIBDIR _build
+          meson setup _build --prefix=/usr --libdir=/usr/lib/x86_64-linux-gnu
           meson compile -C _build
           meson install -C _build

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   freebsd:
-    runs-on: macos-12
+    runs-on: ubuntu-latest
     steps:
     - name: checkout libva
       uses: actions/checkout@v3
@@ -24,7 +24,7 @@ jobs:
       with:
         path: libva-utils
     - name: test
-      uses: vmactions/freebsd-vm@v0
+      uses: vmactions/freebsd-vm@v1
       with:
         prepare: |
           pkg install -y meson pkgconf libdrm libXext libXfixes wayland


### PR DESCRIPTION
The previous v0 is not working anymore.
Update to use the latest v1 version.
same as https://github.com/intel/libva/pull/775
&https://github.com/intel/libva-utils/pull/352

but last one was closed unfortunately.