### PR TITLE
Fixed build with -std=c++20

### DIFF
--- a/decode/mpeg2vldemo.cpp
+++ b/decode/mpeg2vldemo.cpp
@@ -79,8 +79,8 @@ static VAPictureParameterBufferMPEG2 pic_param = {
     .backward_reference_picture = 0xffffffff,
     .picture_coding_type = 1,
     .f_code = 0xffff,
-    {
-        {
+    .picture_coding_extension = {
+        .bits = {
             .intra_dc_precision = 0,
             .picture_structure = 3,
             .top_field_first = 0,


### PR DESCRIPTION
upcoming gcc-16 will change the default to c++20

fixes:
```c++
    ../decode/mpeg2vldemo.cpp:82:5: error: either all initializer clauses should be designated or none of them should be
       82 |     {
          |     ^
``` 