### PR TITLE
fix: remove duplicate differential_mode output

### DIFF
--- a/common/va_display.c
+++ b/common/va_display.c
@@ -52,7 +52,8 @@ static const VADisplayHooks *g_display_hooks_available[] = {
 #ifdef HAVE_VA_DRM
     &va_display_hooks_drm,
 #endif
-    NULL};
+    NULL
+};
 
 static const char *g_display_name;
 const char *g_device_name;

--- a/vainfo/vainfo.c
+++ b/vainfo/vainfo.c
@@ -331,7 +331,6 @@ static int show_config_attributes(VADisplay va_dpy, VAProfile profile, VAEntrypo
         printf("%-*sprogressive_dct_mode=%d\n", 45, "", config->bits.progressive_dct_mode);
         printf("%-*snon_interleaved_mode=%d\n", 45, "", config->bits.non_interleaved_mode);
         printf("%-*sdifferential_mode=%d\n", 45, "", config->bits.differential_mode);
-        printf("%-*sdifferential_mode=%d\n", 45, "", config->bits.differential_mode);
         printf("%-*smax_num_components=%d\n", 45, "", config->bits.max_num_components);
         printf("%-*smax_num_scans=%d\n", 45, "", config->bits.max_num_scans);
         printf("%-*smax_num_huffman_tables=%d\n", 45, "", config->bits.max_num_huffman_tables);


### PR DESCRIPTION
Hello, I've noticed a formatting issue and some duplicate statements. Could you please help review them and let me know if they need to be corrected? Thank you!