### PR TITLE
fix: remove VA_ENC_PACKED_HEADER_RAW_DATA from VAConfigAttribEncInterlaced list

### DIFF
--- a/vainfo/vainfo.c
+++ b/vainfo/vainfo.c
@@ -258,8 +258,7 @@ static int show_config_attributes(VADisplay va_dpy, VAProfile profile, VAEntrypo
                 {VA_ENC_INTERLACED_FRAME,       "VA_ENC_INTERLACED_FRAME"},
                 {VA_ENC_INTERLACED_FIELD,       "VA_ENC_INTERLACED_FIELD"},
                 {VA_ENC_INTERLACED_MBAFF,       "VA_ENC_INTERLACED_MBAFF"},
-                {VA_ENC_INTERLACED_PAFF,        "VA_ENC_INTERLACED_PAFF"},
-                {VA_ENC_PACKED_HEADER_RAW_DATA, "VA_ENC_PACKED_HEADER_RAW_DATA"},
+                {VA_ENC_INTERLACED_PAFF,        "VA_ENC_INTERLACED_PAFF"}
             };
             for (i = 0, n = 0; i < sizeof(list) / sizeof(list[0]); i++) {
                 if (attrib_list[VAConfigAttribEncInterlaced].value & list[i].format) {


### PR DESCRIPTION
Hello, could you please help me review this? I want to confirm if this change is appropriate: The VA_ENC_PACKED_HEADER_RAW_DATA value belongs to packed headers attributes, not the interlaced encoding attributes.

Thank you for your help!