### PR TITLE
fix: set general_profile_idc in bitstream when --profile is not speci…

### DIFF
--- a/encode/hevcencode.c
+++ b/encode/hevcencode.c
@@ -2029,16 +2029,19 @@ static int init_va(void)
         switch (hevc_profile) {
         case VAProfileHEVCMain:
             hevc_profile = VAProfileHEVCMain;
+            real_hevc_profile = PROFILE_IDC_MAIN;
             printf("Use profile VAProfileHEVCMain\n");
             break;
 
         case VAProfileHEVCMain10:
             hevc_profile = VAProfileHEVCMain10;
+            real_hevc_profile = PROFILE_IDC_MAIN10;
             printf("Use profile VAProfileHEVCMain10\n");
             break;
         default:
             printf("unknow profile. Set to Main");
             hevc_profile = VAProfileHEVCMain;
+            real_hevc_profile = PROFILE_IDC_MAIN;
             constraint_set_flag |= (1 << 0 | 1 << 1); /* Annex A.2.1 & A.2.2 */
             ip_period = 1;
             break;


### PR DESCRIPTION
…fied

When --profile is omitted, real_hevc_profile stays at its initial value of 0 even though hevc_profile is correctly auto-detected. This writes general_profile_idc=0 into VPS/SPS, producing a non-conformant HEVC bitstream that decoders reject with "Unknown HEVC profile: 0".

Set real_hevc_profile to match the auto-detected VA-API profile in the init_va() switch block so the bitstream always contains the correct profile indicator.